### PR TITLE
Update nvr spec conformance

### DIFF
--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1051,57 +1051,61 @@ components:
       type: object
       title: Rule
       properties:
-        objectId:
-          description: Id of rule
-          type: integer
-          format: int64
-        nvrId:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        foreskriftstyp:
-          description: Type of rule
-          type: string
-        foreskriftssubtyp:
-          description: Subtype of rule
-          type: string
-        franDatum:
-          description: Date that the rule is in effect from
-          type: string
-        tillDatum:
-          description: Date that the rule is in effect to
-          type: string
-        areaHa:
-          description: Size of the area affected by the rule
-          type: number
-        foreskriftstypKod:
-          description: Code for the rule
-          type: string
-        foreskriftssubtypKod:
-          description: Code for the rule subtype
-          type: string
-        atomLink:
-          description: ""
-          type: array
-          items:
-            type: object
-      example:
-        objectId: 2493200
-        nvrId: 2001362
-        beslutsstatus: Gällande
-        foreskriftstyp: Tillträdesförbud
-        foreskriftssubtyp: Fågel
-        franDatum: 1/3
-        tillDatum: 15/8
-        areaHa: 722.488
-        foreskriftstypKod: 2
-        foreskriftssubtypKod: 2
-        atomLink:
-          - {"@rel": "self"}
-          - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/foreskriftsomrade/2001362/G%C3%A4llande/2493200"}
-      description: Area affected by a rule
+        foreskriftsomrade:
+          type: object
+          properties:
+            objectId:
+              description: Id of rule
+              type: integer
+              format: int64
+            nvrId:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            foreskriftstyp:
+              description: Type of rule
+              type: string
+            foreskriftssubtyp:
+              description: Subtype of rule
+              type: string
+            franDatum:
+              description: Date that the rule is in effect from
+              type: string
+            tillDatum:
+              description: Date that the rule is in effect to
+              type: string
+            areaHa:
+              description: Size of the area affected by the rule
+              type: number
+            foreskriftstypKod:
+              description: Code for the rule
+              type: number
+            foreskriftssubtypKod:
+              description: Code for the rule subtype
+              type: number
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            objectId: 2493200
+            nvrId: 2001362
+            beslutsstatus: Gällande
+            foreskriftstyp: Tillträdesförbud
+            foreskriftssubtyp: Fågel
+            franDatum: 1/3
+            tillDatum: 15/8
+            areaHa: 722.488
+            foreskriftstypKod: 2
+            foreskriftssubtypKod: 2
+            atomLink:
+              - {"@rel": "self"}
+              - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/foreskriftsomrade/2001362/G%C3%A4llande/2493200"}
+          description: Area affected by a rule
 
     Miljomal:
       type: object
@@ -1425,16 +1429,19 @@ components:
       type: object
       title: Type
       properties:
-        key:
-          description: ""
-          type: string
-        value:
-          description: ""
-          type: string
-      example:
-        key: key
-        value: value
-      description: Used by value lists
+        typ:
+          type: object
+          properties:
+            key:
+              description: ""
+              type: string
+            value:
+              description: ""
+              type: string
+          example:
+            key: key
+            value: value
+          description: Used by value lists
 
     WktString:
       type: string

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -300,7 +300,7 @@ paths:
                 description: List(Omrade)
                 type: array
                 items:
-                  $ref: "#/components/schemas/Omrade"
+                  $ref: "#/components/schemas/OmradeNoLinks"
 
   /omrade/extentAsWkt:
     get:
@@ -1171,84 +1171,88 @@ components:
       type: object
       title: Site (no links)
       properties:
-        id:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        namn:
-          description: Name of site
-          type: string
-        skyddstyp:
-          description: Protection type
-          type: string
-        lanAsText:
-          description: Region name(s)
-          type: string
-        kommunerAsText:
-          description: Municipality name(s)
-          type: string
-        beslutstyp:
-          description: Type of decision
-          type: string
-        beslutsdatum:
-          description: Date of decision
-          type: integer
-          format: int32
-        ursprBeslutsdatum:
-          description: Original decision date
-          type: integer
-          format: int32
-        gallandedatum:
-          description: Current decision date
-          type: integer
-          format: int32
-        iucnKategori:
-          description: IUCN category
-          type: string
-        forvaltare:
-          description: Public administration
-          type: string
-        areaHa:
-          description: Area in hecatres
-          type: number
-        landareaHa:
-          description: Land area in hectares
-          type: number
-        vattenareaHa:
-          description: Water area in hectares
-          type: number
-        skogAreaHa:
-          description: Forest area in hectares
-          type: number
-        beslutsmyndighet:
-          description: Authority
-          type: string
-        atomLink:
+        omrade:
+          type: object
+          properties:
+            id:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            namn:
+              description: Name of site
+              type: string
+            skyddstyp:
+              description: Protection type
+              type: string
+            lanAsText:
+              description: Region name(s)
+              type: string
+            kommunerAsText:
+              description: Municipality name(s)
+              type: string
+            beslutstyp:
+              description: Type of decision
+              type: string
+            beslutsdatum:
+              description: Date of decision
+              type: string
+              format: date-time
+            ursprBeslutsdatum:
+              description: Original decision date
+              type: string
+              format: date-time
+            gallandedatum:
+              description: Current decision date
+              type: string
+              format: date-time
+            iucnKategori:
+              description: IUCN category
+              type: string
+            forvaltare:
+              description: Public administration
+              type: string
+            areaHa:
+              description: Area in hecatres
+              type: number
+            landareaHa:
+              description: Land area in hectares
+              type: number
+            vattenareaHa:
+              description: Water area in hectares
+              type: number
+            skogAreaHa:
+              description: Forest area in hectares
+              type: number
+            beslutsmyndighet:
+              description: Authority
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            id: 2001362
+            beslutsstatus: Gällande
+            namn: "Store Mosse"
+            skyddstyp: "Nationalpark"
+            lanAsText: "Jönköpings Län"
+            kommunerAsText: "Gnosjö, Vaggeryd, Värnamo"
+            beslutstyp: "Beslut om bildande av Nationalpark"
+            beslutsdatum: "1982-05-06T00:00:00+02:00"
+            ursprBeslutsdatum: "1982-05-06T00:00:00+02:00"
+            gallandedatum: "1982-05-06T00:00:00+02:00"
+            iucnKategori: "II, Nationalpark (National Park)"
+            forvaltare: "Länsstyrelsen i Jönköpings län"
+            areaHa: 12345
+            landareaHa: 7409.47
+            vattenareaHa: 264.64
+            skogAreaHa: 652.15
+            beslutsmyndighet: "Riksdag/Regering"
           description: ""
-          type: array
-          items:
-            type: object
-      example:
-        id: 2001362
-        beslutsstatus: Gällande
-        namn: "Store Mosse"
-        skyddstyp: "Nationalpark"
-        lanAsText: "Jönköpings Län"
-        kommunerAsText: "Gnosjö, Vaggeryd, Värnamo"
-        beslutstyp: "Beslut om bildande av Nationalpark"
-        beslutsdatum: "1982-05-06T00:00:00+02:00"
-        ursprBeslutsdatum: "1982-05-06T00:00:00+02:00"
-        gallandedatum: "1982-05-06T00:00:00+02:00"
-        iucnKategori: "II, Nationalpark (National Park)"
-        forvaltare: "Länsstyrelsen i Jönköpings län"
-        areaHa: 12345
-        landareaHa: 7409.47
-        vattenareaHa: 264.64
-        skogAreaHa: 652.15
-        beslutsmyndighet: "Riksdag/Regering"
-      description: ""
 
     Omrade:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1107,28 +1107,32 @@ components:
       type: object
       title: Environmental objective
       properties:
-        nvrId:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        namn:
-          description: Name of environmental objective
-          type: string
-        atomLink:
+        miljomal:
+          type: object
+          properties:
+            nvrId:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            namn:
+              description: Name of environmental objective
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            nvrId: 2001362
+            beslutsstatus: Gällande
+            namn: "12. Levande skogar"
+            atomLink:
+              - {"@rel": "self"}
+              - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/miljomal/2001362/G%C3%A4llande/12.%20Levande%20skogar"}
           description: ""
-          type: array
-          items:
-            type: object
-      example:
-        nvrId: 2001362
-        beslutsstatus: Gällande
-        namn: "12. Levande skogar"
-        atomLink:
-          - {"@rel": "self"}
-          - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/miljomal/2001362/G%C3%A4llande/12.%20Levande%20skogar"}
-      description: ""
 
     NmdKlass:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1384,7 +1384,7 @@ components:
 "@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/omrade/2001362/G%C3%A4llande/foreskriftsomraden"
 }
 ]
-                description: ""
+            description: ""
 
     Syfte:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1134,44 +1134,49 @@ components:
       type: object
       title: NMD class
       properties:
-        nvrId:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        kod:
-          description: NMD class code
-          type: string
-        namn:
-          description: NMD class name
-          type: string
-        areaHa:
-          description: Area in hectares
-          type: number
-        foreskriftstyp:
-          description: Rule type
-          type: string
-        foreskriftstypNamn:
-          description: Rule type name
-          type: string
-        atomLink:
+        nmdKlass:
+          type: object
+          properties:
+            nvrId:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            kod:
+              description: NMD class code
+              type: integer
+              format: int32
+            namn:
+              description: NMD class name
+              type: string
+            areaHa:
+              description: Area in hectares
+              type: number
+            foreskriftstyp:
+              description: Rule type
+              type: number
+            foreskriftstypNamn:
+              description: Rule type name
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            nvrId: 2001362
+            beslutsstatus: Gällande
+            kod: 111
+            namn: "Tallskog utanför våtmark"
+            areaHa: 12345
+            foreskriftstyp: 0
+            foreskriftstypNamn: "Ej foreskrift"
+            atomLink:
+              - {"@rel": "self"}
+              - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/nmdklass/2001362/G%C3%A4llande/111"}
           description: ""
-          type: array
-          items:
-            type: object
-      example:
-        nvrId: 2001362
-        beslutsstatus: Gällande
-        kod: 111
-        namn: "Tallskog utanför våtmark"
-        areaHa: 12345
-        foreskriftstyp: 0
-        foreskriftstypNamn: "Ej foreskrift"
-        atomLink:
-          - {"@rel": "self"}
-          - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/nmdklass/2001362/G%C3%A4llande/111"}
-      description: ""
 
     OmradeNoLinks:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1254,84 +1254,88 @@ components:
       type: object
       title: Site
       properties:
-        id:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        namn:
-          description: Name of site
-          type: string
-        skyddstyp:
-          description: Protection type
-          type: string
-        lanAsText:
-          description: Region name(s)
-          type: string
-        kommunerAsText:
-          description: Municipality name(s)
-          type: string
-        beslutstyp:
-          description: Type of decision
-          type: string
-        beslutsdatum:
-          description: Date of decision
-          type: integer
-          format: int32
-        ursprBeslutsdatum:
-          description: Original decision date
-          type: integer
-          format: int32
-        gallandedatum:
-          description: Current decision date
-          type: integer
-          format: int32
-        iucnKategori:
-          description: IUCN category
-          type: string
-        forvaltare:
-          description: Public administration
-          type: string
-        areaHa:
-          description: Area in hecatres
-          type: number
-        landareaHa:
-          description: Land area in hectares
-          type: number
-        vattenareaHa:
-          description: Water area in hectares
-          type: number
-        skogAreaHa:
-          description: Forest area in hectares
-          type: number
-        beslutsmyndighet:
-          description: Authority
-          type: string
-        atomLink:
-          description: ""
-          type: array
-          items:
-            type: object
-      example:
-        id: 2001362
-        beslutsstatus: Gällande
-        namn: "Store Mosse"
-        skyddstyp: "Nationalpark"
-        lanAsText: "Jönköpings Län"
-        kommunerAsText: "Gnosjö, Vaggeryd, Värnamo"
-        beslutstyp: "Beslut om bildande av Nationalpark"
-        beslutsdatum: "1982-05-06T00:00:00+02:00"
-        ursprBeslutsdatum: "1982-05-06T00:00:00+02:00"
-        gallandedatum: "1982-05-06T00:00:00+02:00"
-        iucnKategori: "II, Nationalpark (National Park)"
-        forvaltare: "Länsstyrelsen i Jönköpings län"
-        areaHa: 12345
-        landareaHa: 7409.47
-        vattenareaHa: 264.64
-        skogAreaHa: 652.15
-        beslutsmyndighet: "Riksdag/Regering"
-        atomLink: [
+        omrade:
+          type: object
+          properties:
+            id:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            namn:
+              description: Name of site
+              type: string
+            skyddstyp:
+              description: Protection type
+              type: string
+            lanAsText:
+              description: Region name(s)
+              type: string
+            kommunerAsText:
+              description: Municipality name(s)
+              type: string
+            beslutstyp:
+              description: Type of decision
+              type: string
+            beslutsdatum:
+              description: Date of decision
+              type: string
+              format: date-time
+            ursprBeslutsdatum:
+              description: Original decision date
+              type: string
+              format: date-time
+            gallandedatum:
+              description: Current decision date
+              type: string
+              format: date-time
+            iucnKategori:
+              description: IUCN category
+              type: string
+            forvaltare:
+              description: Public administration
+              type: string
+            areaHa:
+              description: Area in hecatres
+              type: number
+            landareaHa:
+              description: Land area in hectares
+              type: number
+            vattenareaHa:
+              description: Water area in hectares
+              type: number
+            skogAreaHa:
+              description: Forest area in hectares
+              type: number
+            beslutsmyndighet:
+              description: Authority
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+              example:
+                id: 2001362
+                beslutsstatus: Gällande
+                namn: "Store Mosse"
+                skyddstyp: "Nationalpark"
+                lanAsText: "Jönköpings Län"
+                kommunerAsText: "Gnosjö, Vaggeryd, Värnamo"
+                beslutstyp: "Beslut om bildande av Nationalpark"
+                beslutsdatum: "1982-05-06T00:00:00+02:00"
+                ursprBeslutsdatum: "1982-05-06T00:00:00+02:00"
+                gallandedatum: "1982-05-06T00:00:00+02:00"
+                iucnKategori: "II, Nationalpark (National Park)"
+                forvaltare: "Länsstyrelsen i Jönköpings län"
+                areaHa: 12345
+                landareaHa: 7409.47
+                vattenareaHa: 264.64
+                skogAreaHa: 652.15
+                beslutsmyndighet: "Riksdag/Regering"
+                atomLink: [
 {
 "@rel": "nmdklasser",
 "@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/omrade/2001362/G%C3%A4llande/nmdklasser"
@@ -1357,7 +1361,7 @@ components:
 "@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/omrade/2001362/G%C3%A4llande/foreskriftsomraden"
 }
 ]
-      description: ""
+                description: ""
 
     Syfte:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -976,70 +976,76 @@ components:
       type: object
       title: Decision document
       properties:
-        nvrId:
-          description: NVR-id of site
-          type: string
-        beslutsId:
-          description: Id of decision
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        beslutstyp:
-          description: Decision type
-          type: string
-        beslutsmyndighet:
-          description: Authority
-          type: string
-        diarienummer:
-          description: Registration number
-          type: string
-        beslutsdatum:
-          description: Decision date
-          type: integer
-          format: int32
-        gallandedatum:
-          description: Current decision date
-          type: integer
-          format: int32
-        id:
-          description: Id of document
-          type: string
-        namn:
-          description: Name of document
-          type: string
-        typ:
-          description: Type of document
-          type: string
-        mimeType:
-          description: MIME type of document
-          type: string
-        fileUrl:
-          description: URL to document file
-          type: string
-        atomLink:
+        beslutsdokument:
+          type: object
+          properties:
+            nvrId:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsId:
+              description: Id of decision
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            beslutstyp:
+              description: Decision type
+              type: string
+            beslutsmyndighet:
+              description: Authority
+              type: string
+            diarienummer:
+              description: Registration number
+              type: string
+            beslutsdatum:
+              description: Decision date
+              type: string
+              format: date-time
+            gallandedatum:
+              description: Current decision date
+              type: string
+              format: date-time
+            id:
+              description: Id of document
+              type: integer
+              format: int32
+            namn:
+              description: Name of document
+              type: string
+            typ:
+              description: Type of document
+              type: string
+            mimeType:
+              description: MIME type of document
+              type: string
+            fileUrl:
+              description: URL to document file
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            nvrId: 2001362
+            beslutsId: 100043
+            beslutsstatus: "Gällande"
+            beslutstyp: "Beslut om bildande av Nationalpark"
+            beslutsmyndighet: "Riksdag/Regering"
+            diarienummer: "JODEP 2516/79, 784/82 SNV 203-3207-81"
+            beslutsdatum: "1982-05-06T00:00:00+02:00"
+            gallandedatum: "1982-05-06T00:00:00+02:00"
+            id: 151124
+            namn: "Store mosse Regeringens beslut.pdf"
+            typ: "Beslut"
+            mimeType: "application/pdf"
+            fileUrl: "https://nvpub.vic-metria.nu/handlingar/rest/dokument/151124"
+            atomLink:
+              - {"@rel": "self"}
+              - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/beslutsdokument/2001362/G%C3%A4llande/151124"}
           description: ""
-          type: array
-          items:
-            type: object
-      example:
-        nvrId: 2001362
-        beslutsId: 100043
-        beslutsstatus: "Gällande"
-        beslutstyp: "Beslut om bildande av Nationalpark"
-        beslutsmyndighet: "Riksdag/Regering"
-        diarienummer: "JODEP 2516/79, 784/82 SNV 203-3207-81"
-        beslutsdatum: "1982-05-06T00:00:00+02:00"
-        gallandedatum: "1982-05-06T00:00:00+02:00"
-        id: 151124
-        namn: "Store mosse Regeringens beslut.pdf"
-        typ: "Beslut"
-        mimeType: "application/pdf"
-        fileUrl: "https://nvpub.vic-metria.nu/handlingar/rest/dokument/151124"
-        atomLink:
-          - {"@rel": "self"}
-          - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/beslutsdokument/2001362/G%C3%A4llande/151124"}
-      description: ""
 
     Foreskriftsomrade:
       type: object

--- a/static/nvr_api.yaml
+++ b/static/nvr_api.yaml
@@ -1377,36 +1377,40 @@ components:
       type: object
       title: Purpose
       properties:
-        nvrId:
-          description: NVR-id of site
-          type: string
-        beslutsstatus:
-          description: Decision status
-          type: string
-        id:
-          description: Id of purpose
-          type: string
-        namn:
-          description: Name of purpose
-          type: string
-        beskrivning:
-          description: Description of purpose
-          type: string
-        atomLink:
+        syfte:
+          type: object
+          properties:
+            nvrId:
+              description: NVR-id of site
+              type: integer
+              format: int32
+            beslutsstatus:
+              description: Decision status
+              type: string
+            id:
+              description: Id of purpose
+              type: string
+            namn:
+              description: Name of purpose
+              type: string
+            beskrivning:
+              description: Description of purpose
+              type: string
+            atomLink:
+              description: ""
+              type: array
+              items:
+                type: object
+          example:
+            nvrId: 2001362
+            beslutsstatus: Gällande
+            id: "2.19.34"
+            namn: "Vårda och bevara värdefulla naturmiljöer"
+            beskrivning: "Liminiska miljöer, Sjö"
+            atomLink:
+              - {"@rel": "self"}
+              - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/syfte/2001362/G%C3%A4llande/2.19.34"}
           description: ""
-          type: array
-          items:
-            type: object
-      example:
-        nvrId: 2001362
-        beslutsstatus: Gällande
-        id: "2.19.34"
-        namn: "Vårda och bevara värdefulla naturmiljöer"
-        beskrivning: "Liminiska miljöer, Sjö"
-        atomLink:
-          - {"@rel": "self"}
-          - {"@href": "https://nvpub.vic-metria.nu/naturvardsregistret/v2/rest/syfte/2001362/G%C3%A4llande/2.19.34"}
-      description: ""
 
     Typ:
       type: object


### PR DESCRIPTION
I'm on a team that is writing an automated conformance testing tool for OpenApi specifications, and your spec was a great one to work with. Since I already had the changes, I thought it would be a good idea to put them in a PR.

A good example of the changes is in the Beslutsdokument schema:
![image](https://user-images.githubusercontent.com/13511813/140531675-2d869f97-fe63-4dd1-a159-271331896a90.png)

The response came back with a nested "beslutsdokument" property, which had to be documented in the spec like so:
![image](https://user-images.githubusercontent.com/13511813/140624694-e03ba7fe-3f42-4bc3-b441-184b45bcfc14.png)


From the original:
![image](https://user-images.githubusercontent.com/13511813/140624597-b2a3b72a-9641-4cba-8ce6-0083aa228fc6.png)

Other examples included changes like "nvrId" being listed as a string in the spec, but coming back as an integer in the response, and gallandedatum being listed as an integer, but coming back as a string with a date-time format.